### PR TITLE
Add ReSharper 2020 support, refactoring

### DIFF
--- a/src/Arbel.ReSharper.ConfigureAwaitPlugin/Arbel.ReSharper.ConfigureAwaitPlugin.csproj
+++ b/src/Arbel.ReSharper.ConfigureAwaitPlugin/Arbel.ReSharper.ConfigureAwaitPlugin.csproj
@@ -1,10 +1,25 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
-    <Title>ReSharper ConfigureAwait Checker</Title>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <IsPackable>True</IsPackable>
+
+    <Title>ReSharper ConfigureAwait Checker</Title>
+    <Authors>Eli Arbel</Authors>
+    <Description>Library code should use ConfigureAwait with every await. Always specifying ConfigureAwait makes it clearer how the continuation is invoked and avoids synchronization bugs.</Description>
+    <Copyright>Copyright &#x00A9; Eli Arbel</Copyright>
+    <PackageTags>resharper await async configureawait</PackageTags>
+    <PackageProjectUrl>https://github.com/aelij/ConfigureAwaitChecker/</PackageProjectUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+  </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.3.0" />
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="$(SdkVersion)" PrivateAssets="all" />
+    <!-- TODO: https://github.com/NuGet/Home/issues/7154 -->
+    <PackageReference Include="Wave" Version="$(WaveVersion)" />
   </ItemGroup>
+
 </Project>

--- a/src/Arbel.ReSharper.sln
+++ b/src/Arbel.ReSharper.sln
@@ -3,11 +3,16 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arbel.ReSharper.ConfigureAwaitPlugin", "Arbel.ReSharper.ConfigureAwaitPlugin\Arbel.ReSharper.ConfigureAwaitPlugin.csproj", "{F3159B18-F527-42FE-AAE8-B60EEC81E0A3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arbel.ReSharper.ConfigureAwaitPlugin", "Arbel.ReSharper.ConfigureAwaitPlugin\Arbel.ReSharper.ConfigureAwaitPlugin.csproj", "{F3159B18-F527-42FE-AAE8-B60EEC81E0A3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arbel.ReSharper.ConfigureAwaitPlugin.Tests", "Arbel.ReSharper.ConfigureAwaitPlugin.Tests\Arbel.ReSharper.ConfigureAwaitPlugin.Tests.csproj", "{D4073F03-F08B-466B-8667-2B2A55B2F30B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arbel.ReSharper.ConfigureAwaitPlugin.Tests", "Arbel.ReSharper.ConfigureAwaitPlugin.Tests\Arbel.ReSharper.ConfigureAwaitPlugin.Tests.csproj", "{D4073F03-F08B-466B-8667-2B2A55B2F30B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arbel.Rider.ConfigureAwaitPlugin", "Arbel.ReSharper.ConfigureAwaitPlugin\Arbel.Rider.ConfigureAwaitPlugin.csproj", "{E8F9F4E2-6506-4CAB-9B9A-475E3BE2B88F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arbel.Rider.ConfigureAwaitPlugin", "Arbel.ReSharper.ConfigureAwaitPlugin\Arbel.Rider.ConfigureAwaitPlugin.csproj", "{E8F9F4E2-6506-4CAB-9B9A-475E3BE2B88F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C5172C33-216C-4111-894B-C058E90FEFA1}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -30,5 +35,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {ABB293F2-DB56-4F19-8DD6-273C8DFBF959}
 	EndGlobalSection
 EndGlobal

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,10 +5,9 @@
           Condition=" Exists('$([MSBuild]::GetPathOfFileAbove(`Directory.Build.props`, `$(MSBuildThisFileDirectory)../`))') " />
 
   <PropertyGroup>
-    <BaseIntermediateOutputPath>obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
-    <DefaultItemExcludes>$(DefaultItemExcludes);obj\**</DefaultItemExcludes>
-    <RootNamespace>Arbel.ReSharper.ConfigureAwaitPlugin</RootNamespace>
-    <OutputPath>bin\$(MSBuildProjectName)\$(Configuration)\</OutputPath>
+    <SdkVersion>2019.3.4</SdkVersion>
+    <WaveVersionBase>$(SdkVersion.Substring(2,2))$(SdkVersion.Substring(5,1))</WaveVersionBase>
+    <WaveVersion>$(WaveVersionBase).0.0$(SdkVersion.Substring(8))</WaveVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Add Support for ReSharper 2020 and the EAP builds.
Also refactoring the ReSharper Wave and SDK dependencies in MSBuild.

Bumped version to `0.21.0-preview1`.

**The Preview 1 can be downloaded from this NuGet feed:**

```bash
https://nuget1.mtb.me/f/resharper-public/api/v2/
```

**_Note:_** Please add add the feed to the ReSharper Extension Manager: `ReSharper -> Options -> Environment -> Extension Manager`